### PR TITLE
Added 9 subdomain finder tools hosted online at nmmapper.com

### DIFF
--- a/docs/awesome/files/Security/Offensive/AHSE.md
+++ b/docs/awesome/files/Security/Offensive/AHSE.md
@@ -214,6 +214,7 @@ A curated list of awesome search engines useful during Penetration testing, Vuln
 - [SiteDossier](http://www.sitedossier.com/) - Profiles for millions of sites on the web
 - [SpyOnWeb](https://spyonweb.com/) - Quick and convenient search for the websites that probably belong to the same owner
 - [HaveIBeenSquatted](https://www.haveibeensquatted.com/) - Check if a domain has been typosquatted
+- [9 Subdomain finder tools hosted online](https://www.nmmapper.com/sys/tools/subdomainfinder/) - Amass, Anubis, Knocky, Findomain, Nmap, Censys...
 
 ### URLs
 


### PR DESCRIPTION
Added another comprehensive source of subdomain discovery from nmmapper.com they host 9 subdomain finding tools online, which include

1. Knocky
2. Sublist3r
3. DNScan
4. Anubis subdomain finder
5. Amass
6. Nmap(dns-brute.nse)
7. Lepus
8. Censys
9. Findomain